### PR TITLE
Detect MCCs from the same country as equal

### DIFF
--- a/src/net/volatilevoid/nationalroaming/NationalRoaming.java
+++ b/src/net/volatilevoid/nationalroaming/NationalRoaming.java
@@ -7,12 +7,30 @@ import de.robv.android.xposed.XposedBridge;
 import de.robv.android.xposed.callbacks.XC_LoadPackage.LoadPackageParam;
 
 import java.lang.reflect.*;
+import java.util.HashMap;
 import android.telephony.ServiceState;
 import android.os.Build;
 
 public class NationalRoaming implements IXposedHookLoadPackage {
 
     private static final String TAG = "National Roaming: ";
+
+    // based on http://www.insys-icom.com/mcc/
+    public static final HashMap<String, String> baseCountryCodes = new HashMap<String, String>();
+    static {
+        baseCountryCodes.put("311", "310"); // USA
+        baseCountryCodes.put("312", "310"); // USA
+        baseCountryCodes.put("313", "310"); // USA
+        baseCountryCodes.put("314", "310"); // USA
+        baseCountryCodes.put("315", "310"); // USA
+        baseCountryCodes.put("316", "310"); // USA
+        baseCountryCodes.put("430", "424"); // United Arab Emirates
+        baseCountryCodes.put("431", "424"); // United Arab Emirates
+        baseCountryCodes.put("441", "440"); // Japan
+        baseCountryCodes.put("461", "460"); // China
+        baseCountryCodes.put("405", "404"); // India
+        baseCountryCodes.put("235", "234"); // United Kingdom
+    }
 
     @Override
     public void handleLoadPackage(LoadPackageParam lpparam) throws Throwable {
@@ -60,8 +78,20 @@ public class NationalRoaming implements IXposedHookLoadPackage {
 
                         String net = newSS.getOperatorNumeric();
 
-                        if (sim.substring(0, 3).equals(net.substring(0, 3)))
+                        String simMcc = sim.substring(0,3);
+                        String netMcc = net.substring(0,3);
+
+                        if (simMcc.equals(netMcc) || baseMcc(simMcc).equals(baseMcc(netMcc)))
                             newSS.setRoaming(false); // MCC is the same - we're at home
+                    }
+
+                    protected String baseMcc(String mcc) {
+                        String baseMcc = baseCountryCodes.get(mcc);
+                        if (baseMcc != null) {
+                                return baseMcc;
+                        } else {
+                                return mcc;
+                        }
                     }
                 }
                 );


### PR DESCRIPTION
Create a hashmap from each of a country's other MCCs back to a "base" MCC
(chosen arbitrarily) so that they all show as equal. For MCCs that are already
the same, skip the mapping to maintain performance. (The only change for MCCs
that are the same should be provisioning the map in the first place.)
